### PR TITLE
Adjust notes in benchmark output

### DIFF
--- a/bench_wizard/output.py
+++ b/bench_wizard/output.py
@@ -4,10 +4,6 @@ from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from .benchmark import Benchmark
 
-# TODO: need as configurable option
-DIFF_MARGIN = 10  # percent
-
-
 class Output:
     """A class used to handle console output"""
 
@@ -60,11 +56,11 @@ class Output:
     def footnote(self):
         self.print("\nNotes:")
         self.print(
-            "* - diff means the difference between reference total time and total benchmark time of current machine"
+            "- in the diff fields you can see the difference between the reference benchmark time and the benchmark time of your machine"
         )
         self.print(
-            f"* - if diff > {DIFF_MARGIN}% of ref value -> performance is same or better"
+            f"- if diff is positive for all three pallets, your machine covers the minimum requirements for running a HydraDX node"
         )
         self.print(
-            f"* - If diff < {DIFF_MARGIN}% of ref value -> performance is worse and might not be suitable to run node ( You may ask node devs for further clarifications)"
+            f"- if diff is negative for one of the pallets, your machine might not be suitable to run a node"
         )

--- a/bench_wizard/output.py
+++ b/bench_wizard/output.py
@@ -4,6 +4,9 @@ from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from .benchmark import Benchmark
 
+# TODO: need as configurable option
+DIFF_MARGIN = 10  # percent
+
 class Output:
     """A class used to handle console output"""
 
@@ -62,5 +65,5 @@ class Output:
             f"- if diff is positive for all three pallets, your machine covers the minimum requirements for running a HydraDX node"
         )
         self.print(
-            f"- if diff is negative for one (or more) of the pallets, your machine might not be suitable to run a node"
+            f"- if diff deviates by -{DIFF_MARGIN}% or more for some of the pallets, your machine might not be suitable to run a node"
         )

--- a/bench_wizard/output.py
+++ b/bench_wizard/output.py
@@ -62,5 +62,5 @@ class Output:
             f"- if diff is positive for all three pallets, your machine covers the minimum requirements for running a HydraDX node"
         )
         self.print(
-            f"- if diff is negative for one of the pallets, your machine might not be suitable to run a node"
+            f"- if diff is negative for one (or more) of the pallets, your machine might not be suitable to run a node"
         )


### PR DESCRIPTION
Per request of @jak-pan in https://github.com/galacticcouncil/HydraDX-docs/pull/36

If we want 0% or better, shall we also set `DIFF_MARGIN=0`? https://github.com/galacticcouncil/bench-wizard/blob/main/bench_wizard/benchmark.py#L14

cc @enthusiastmartin 