### PR TITLE
fix: use local chainspec

### DIFF
--- a/bench_wizard/cargo.py
+++ b/bench_wizard/cargo.py
@@ -6,7 +6,7 @@ from typing import Optional, List
 class Cargo:
     pallet: str
     manifest: str = "node/Cargo.toml"
-    chain: str = "dev"
+    chain: str = "local"
     steps: int = 5
     repeat: int = 20
     extrinsic: str = "*"


### PR DESCRIPTION
Dev chainspec has been removed from hydra parachain repo. Use local config instead.